### PR TITLE
Review for termination

### DIFF
--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -4,8 +4,6 @@ import numpy as np
 from datetime import datetime
 from .step_termination import _read_termination
 import numbers
-from enum import Enum
-from typing import Union, Optional
 
 _examples = """
 
@@ -24,12 +22,6 @@ _examples = """
     "Discharge at C/3 for 2 hours or until 2.5 V",
 
     """
-
-
-class Direction(Enum):
-    charge = "charge"
-    discharge = "discharge"
-    rest = "rest"
 
 
 class BaseStep:
@@ -75,17 +67,13 @@ class BaseStep:
         tags=None,
         start_time=None,
         description=None,
-        direction: Optional[Union[str, Direction]] = None,
+        direction: str | None = None,
     ):
-        try:
-            direction = Direction(direction)
-        except ValueError as e:
-            if direction is None:
-                pass
-            else:
-                raise ValueError(
-                    f"Invalid direction: {direction}. Must be one of {Direction.__members__.values()}"
-                ) from e
+        potential_directions = ["charge", "discharge", "rest", None]
+        if direction not in potential_directions:
+            raise ValueError(
+                f"Invalid direction: {direction}. Must be one of {potential_directions}"
+            )
         self.input_duration = duration
         self.input_duration = duration
         self.input_value = value

--- a/src/pybamm/experiment/step/step_termination.py
+++ b/src/pybamm/experiment/step/step_termination.py
@@ -73,15 +73,15 @@ class CurrentTermination(BaseTermination):
         operator = self.operator
         if operator == ">":
             expr = self.value - variables["Current [A]"]
-            string = f"Current [A] > {self.value} [A] [experiment]"
+            event_string = f"Current [A] > {self.value} [A] [experiment]"
         elif operator == "<":
             expr = variables["Current [A]"] - self.value
-            string = f"Current [A] < {self.value} [A] [experiment]"
+            event_string = f"Current [A] < {self.value} [A] [experiment]"
         else:
             expr = abs(variables["Current [A]"]) - self.value
-            string = f"abs(Current [A]) < {self.value} [A] [experiment]"
+            event_string = f"abs(Current [A]) < {self.value} [A] [experiment]"
         event = pybamm.Event(
-            string,
+            event_string,
             expr,
         )
         return event


### PR DESCRIPTION
Changes:
- I put the string back instead of the enums. I was trying to refactor the enums and ">"/"<" strings so that only enums were allowed, but after running into a few larger test issues, I figured using enums could just be something for later.
- I renamed a variable to avoid confusion with the type